### PR TITLE
Switch from less stable base box to Bento Centos

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -2,7 +2,7 @@
 # vi: set ft=ruby :
 
 Vagrant.configure(2) do |config|
-  config.vm.box = "centos/7"
+  config.vm.box = "bento/centos-7"
   config.vm.synced_folder ".", "/vagrant", type: "virtualbox"
   config.vm.synced_folder "./ood-home", "/home/ood", type: "virtualbox", mount_options: ["uid=1001","gid=1001"]
 


### PR DESCRIPTION
Something changed in the Centos 7 box such that guest additions could no longer be installed. Numerous other people have reported this issue, and it appears to occur from time to time with new Centos point releases. This is a problem for us because it means that we cannot reliably mount host directories. By switching to Bento Centos 7 we get the advantage of a base box that already has VBox guest additions installed, and should remain functionally stable.