### PR TITLE
Change from single password basic auth to mod_auth_dbm

### DIFF
--- a/ood-setup.sh
+++ b/ood-setup.sh
@@ -1,10 +1,8 @@
 #!/bin/bash
 
 # Install new OOD Portal config
-rm -f /etc/ood/config/ood_portal.yml
-cp /vagrant/ood_portal.yml /etc/ood/config/ood_portal.yml
+cp -f /vagrant/ood_portal.yml /etc/ood/config/ood_portal.yml
 /opt/ood/ood-portal-generator/sbin/update_ood_portal
-systemctl try-restart httpd24-httpd.service httpd24-htcacheclean.service
 
 # Disable SELinux
 setenforce 0

--- a/ood-setup.sh
+++ b/ood-setup.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
 
+# Install new OOD Portal config
+rm -f /etc/ood/config/ood_portal.yml
+cp /vagrant/ood_portal.yml /etc/ood/config/ood_portal.yml
+/opt/ood/ood-portal-generator/sbin/update_ood_portal
+systemctl try-restart httpd24-httpd.service httpd24-htcacheclean.service
+
 # Disable SELinux
 setenforce 0
 sed -i 's/^SELINUX=.*/SELINUX=disabled/g' /etc/sysconfig/selinux
@@ -9,7 +15,7 @@ sed -i 's/^SELINUX=.*/SELINUX=disabled/g' /etc/selinux/config
 groupadd ood
 useradd --create-home --gid ood ood
 echo -n "ood" | passwd --stdin ood
-scl enable httpd24 -- htpasswd -b -c /opt/rh/httpd24/root/etc/httpd/.htpasswd ood ood
+scl enable httpd24 -- htdbm -bc /opt/rh/httpd24/root/etc/httpd/.htpasswd.dbm ood ood
 
 # Misc
 mkdir -p /etc/ood/config/clusters.d

--- a/ood_portal.yml
+++ b/ood_portal.yml
@@ -1,0 +1,245 @@
+---
+#
+# Portal configuration
+#
+
+# The address and port to listen for connections on
+# Example:
+#     listen_addr_port: 443
+# Default: null (don't add any more listen directives)
+#listen_addr_port: null
+
+# The server name used for name-based Virtual Host
+# Example:
+#     servername: 'www.example.com'
+# Default: null (don't use name-based Virtual Host)
+#servername: null
+
+# The port specification for the Virtual Host
+# Example:
+#     port: 8080
+#Default: null (use default port 80 or 443 if SSL enabled)
+#port: null
+
+# List of SSL Apache directives
+# Example:
+#     ssl:
+#       - 'SSLCertificateFile "/etc/pki/tls/certs/www.example.com.crt"'
+#       - 'SSLCertificateKeyFile "/etc/pki/tls/private/www.example.com.key"'
+# Default: null (no SSL support)
+#ssl: null
+
+# Root directory of log files (can be relative ServerRoot)
+# Example:
+#     logroot: '/path/to/my/logs'
+# Default: 'logs' (this is relative to ServerRoot)
+#logroot: 'logs'
+
+# Root directory of the Lua handler code
+# Example:
+#     lua_root: '/path/to/lua/handlers'
+# Default : '/opt/ood/mod_ood_proxy/lib' (default install directory of mod_ood_proxy)
+#lua_root: '/opt/ood/mod_ood_proxy/lib'
+
+# Verbosity of the Lua module logging
+# (see https://httpd.apache.org/docs/2.4/mod/core.html#loglevel)
+# Example:
+#     lua_log_level: 'warn'
+# Default: 'info' (get verbose logs)
+#lua_log_level: 'info'
+
+# System command used to map authenticated-user to system-user
+# Example:
+#     user_map_cmd: '/opt/ood/ood_auth_map/bin/ood_auth_map.regex --regex=''^(\w+)@example.com$'''
+# Default: '/opt/ood/ood_auth_map/bin/ood_auth_map.regex' (this echo's back auth-user)
+#user_map_cmd: '/opt/ood/ood_auth_map/bin/ood_auth_map.regex'
+
+# Use an alternative CGI environment variable instead of REMOTE_USER for
+# determining the authenticated-user fed to the mapping script
+# Example:
+#     user_env: 'OIDC_CLAIM_preferred_username'
+# Default: null (use REMOTE_USER)
+#user_env: null
+
+# Redirect user to the following URI if fail to map there authenticated-user to
+# a system-user
+# Example:
+#     map_fail_uri: '/register'
+# Default: null (don't redirect, just display error message)
+#map_fail_uri: null
+
+# System command used to run the `nginx_stage` script with sudo privileges
+# Example:
+#     pun_stage_cmd: 'sudo /path/to/nginx_stage'
+# Default: 'sudo /opt/ood/nginx_stage/sbin/nginx_stage' (don't forget sudo)
+#pun_stage_cmd: 'sudo /opt/ood/nginx_stage/sbin/nginx_stage'
+
+# List of Apache authentication directives
+# NB: Be sure the appropriate Apache module is installed for this
+# Default: (see below, uses basic auth with an htpasswd file)
+#auth:
+#  - 'AuthType Basic'
+#  - 'AuthName "private"'
+#  - 'AuthUserFile "/opt/rh/httpd24/root/etc/httpd/.htpasswd"'
+#  - 'RequestHeader unset Authorization'
+#  - 'Require valid-user'
+
+# Redirect user to the following URI when accessing root URI
+# Example:
+#     root_uri: '/my_uri'
+#     # https://www.example.com/ => https://www.example.com/my_uri
+# Default: '/pun/sys/dashboard' (default location of the OOD Dashboard app)
+#root_uri: '/pun/sys/dashboard'
+
+# Track server-side analytics with a Google Analytics account and property
+# (see https://github.com/OSC/mod_ood_proxy/blob/master/lib/analytics.lua for
+# information on how to setup the GA property)
+# Example:
+#     analytics:
+#       url: 'http://www.google-analytics.com/collect'
+#       id: 'UA-79331310-4'
+# Default: null (do not track)
+#analytics: null
+
+#
+# Publicly available assets
+#
+
+# Public sub-uri (available to public with no authentication)
+# Example:
+#     public_uri: '/assets'
+# Default: '/public'
+#public_uri: '/public'
+
+# Root directory that serves the public sub-uri (be careful, everything under
+# here is open to the public)
+# Example:
+#     public_root: '/path/to/public/assets'
+# Default: '/var/www/ood/public'
+#public_root: '/var/www/ood/public'
+
+#
+# Logout redirect helper
+#
+
+# Logout sub-uri
+# Example
+#     logout_uri: '/log_me_out'
+# NB: If you change this, then modify the Dashboard app with the new sub-uri
+# Default: '/logout' (the Dashboard app is by default going to expect this)
+#logout_uri: '/logout'
+
+# Redirect user to the following URI when accessing logout URI
+# Example:
+#     logout_redirect: '/oidc?logout=https%3A%2F%2Fwww.example.com'
+# Default: '/pun/sys/dashboard/logout' (the Dashboard app provides a simple
+# HTML page explaining logout to the user)
+#logout_redirect: '/pun/sys/dashboard/logout'
+
+#
+# Reverse proxy to backend nodes
+#
+
+# Regular expression used for whitelisting allowed hostnames of nodes
+# Example:
+#     host_regex: '[\w.-]+\.example\.com'
+# Default: '[^/]+' (allow reverse proxying to all hosts, this allows external
+# hosts as well)
+#host_regex: '[^/]+'
+
+# Sub-uri used to reverse proxy to backend web server running on node that
+# knows the full URI path
+# Example:
+#     node_uri: '/node'
+# Default: null (disable this feature)
+#node_uri: null
+
+# Sub-uri used to reverse proxy to backend web server running on node that
+# ONLY uses *relative* URI paths
+# Example:
+#     rnode_uri: '/rnode'
+# Default: null (disable this feature)
+#rnode_uri: null
+
+#
+# Per-user NGINX Passenger apps
+#
+
+# Sub-uri used to control PUN processes
+# Example:
+#     nginx_uri: '/my_pun_controller'
+# Default: '/nginx'
+#nginx_uri: '/nginx'
+
+# Sub-uri used to access the PUN processes
+# Example:
+#     pun_uri: '/my_pun_apps'
+# Default: '/pun'
+#pun_uri: '/pun'
+
+# Root directory that contains the PUN Unix sockets that the proxy uses to
+# connect to
+# Example:
+#     pun_socket_root: '/path/to/pun/sockets'
+# Default: '/var/run/ondemand-nginx' (default location set in nginx_stage)
+#pun_socket_root: '/var/run/ondemand-nginx'
+
+# Number of times the proxy attempts to connect to the PUN Unix socket before
+# giving up and displaying an error to the user
+# Example:
+#     pun_max_retries: 25
+# Default: 5 (only try 5 times)
+#pun_max_retries: 5
+
+#
+# Support for OpenID Connect
+#
+
+# Sub-uri used by mod_auth_openidc for authentication
+# Example:
+#     oidc_uri: '/oidc'
+# Default: null (disable OpenID Connect support)
+#oidc_uri: null
+
+# Sub-uri user is redirected to if they are not authenticated. This is used to
+# *discover* what ID provider the user will login through.
+# Example:
+#     oidc_discover_uri: '/discover'
+# Default: null (disable support for discovering OpenID Connect IdP)
+#oidc_discover_uri: null
+
+# Root directory on the filesystem that serves the HTML code used to display
+# the discovery page
+# Example:
+#     oidc_discover_root: '/var/www/ood/discover'
+# Default: null (disable support for discovering OpenID Connect IdP)
+#oidc_discover_root: null
+
+#
+# Support for registering unmapped users
+#
+# (Not necessary if using regular expressions for mapping users)
+#
+
+# Sub-uri user is redirected to if unable to map authenticated-user to
+# system-user
+# Example:
+#     register_uri: '/register'
+# Default: null (display error to user if mapping fails)
+#register_uri: null
+
+# Root directory on the filesystem that serves the HTML code used to register
+# an unmapped user
+# Example:
+#     register_root: '/var/www/ood/register'
+# Default: null (display error to user if mapping fails)
+#register_root: null
+
+host_regex: 'head'
+auth:
+ - 'AuthType Basic'
+ - 'AuthName "private"'
+ - 'AuthBasicProvider dbm'
+ - 'AuthDBMUserFile "/opt/rh/httpd24/root/etc/httpd/.htpasswd.dbm"'
+ - 'RequestHeader unset Authorization'
+ - 'Require valid-user'


### PR DESCRIPTION
Quoting  #8:

> When I was putting together the KDE I needed to be sure that two users running KDE at the same time would not break the application, which meant adding users to Apache's basic auth. I would prefer if we used a database-backed basic auth like mod_auth_dbm. We could still keep ood as the only default user, but it would simplify creating multi user environments for testing if this was already in place.

Fixes  #8.